### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-json.yml
+++ b/.github/workflows/generate-json.yml
@@ -7,6 +7,8 @@ jobs:
   generate_json:
     name: Generate JSON Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - name: Checkout Repo


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/lohaco-auto-buyer/security/code-scanning/7](https://github.com/legnoh/lohaco-auto-buyer/security/code-scanning/7)

To address the issue, add a `permissions` block to the `generate_json` job giving only the minimal permissions needed—in this case, `contents: write`. This permission is necessary and sufficient to allow the workflow to push changes back to the repository. Insert this block immediately after the `runs-on` key and before `steps` in the `generate_json` job definition (i.e., after line 9, before line 10). No additional methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
